### PR TITLE
Update images digests

### DIFF
--- a/distroless/Dockerfile
+++ b/distroless/Dockerfile
@@ -1,4 +1,4 @@
-FROM cgr.dev/chainguard/python:latest@sha256:333fdfd22fd214412c71b407a4d16d4e2aba41e5b34e683c81ecdb917f7d070a as builder
+FROM cgr.dev/chainguard/python:latest@sha256:08e91d4a86cc9e39829b867b0722234a6440b8ff9faedda57e542f8bf8c2b0c5 as builder
 
 ENV LANG=C.UTF-8
 ENV PYTHONDONTWRITEBYTECODE=1
@@ -12,7 +12,7 @@ COPY requirements.txt .
 
 RUN pip install --no-cache-dir -r requirements.txt
 
-FROM cgr.dev/chainguard/python:latest@sha256:333fdfd22fd214412c71b407a4d16d4e2aba41e5b34e683c81ecdb917f7d070a
+FROM cgr.dev/chainguard/python:latest@sha256:08e91d4a86cc9e39829b867b0722234a6440b8ff9faedda57e542f8bf8c2b0c5
 
 WORKDIR /linky
 


### PR DESCRIPTION
### **User description**
Update images digests

```release-note
NONE
```


## Changes
<details>

```diff
diff --git a/distroless/Dockerfile b/distroless/Dockerfile
index d66729a..c3ca77a 100644
--- a/distroless/Dockerfile
+++ b/distroless/Dockerfile
@@ -1,4 +1,4 @@
-FROM cgr.dev/chainguard/python:latest@sha256:333fdfd22fd214412c71b407a4d16d4e2aba41e5b34e683c81ecdb917f7d070a as builder
+FROM cgr.dev/chainguard/python:latest@sha256:08e91d4a86cc9e39829b867b0722234a6440b8ff9faedda57e542f8bf8c2b0c5 as builder
 
 ENV LANG=C.UTF-8
 ENV PYTHONDONTWRITEBYTECODE=1
@@ -12,7 +12,7 @@ COPY requirements.txt .
 
 RUN pip install --no-cache-dir -r requirements.txt
 
-FROM cgr.dev/chainguard/python:latest@sha256:333fdfd22fd214412c71b407a4d16d4e2aba41e5b34e683c81ecdb917f7d070a
+FROM cgr.dev/chainguard/python:latest@sha256:08e91d4a86cc9e39829b867b0722234a6440b8ff9faedda57e542f8bf8c2b0c5
 
 WORKDIR /linky
 
```

</details>


___

### **PR Type**
enhancement


___

### **Description**
- Update base image digest in `distroless/Dockerfile`

- Ensure both build and runtime stages use the new image digest


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Dockerfile</strong><dd><code>Update Chainguard Python image digest for build and runtime</code></dd></summary>
<hr>

distroless/Dockerfile

<li>Updated the Chainguard Python image digest for both builder and final <br>stages<br> <li> Ensured consistency of image version across build and runtime


</details>


  </td>
  <td><a href="https://github.com/nataliagranato/besides_docker101/pull/70/files#diff-fb14ef66448609a27af89605d2215e4f472c9f0280d1427f163921232146e910">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Atualizado o digest da imagem base utilizada no processo de build e na imagem final do Dockerfile.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->